### PR TITLE
[async.c] fix the memory leak

### DIFF
--- a/async.c
+++ b/async.c
@@ -220,6 +220,7 @@ static void async_destroy(async_p async)
     }
     pthread_mutex_unlock(&async->lock);
     pthread_mutex_destroy(&async->lock);
+    free(async);
 }
 
 static async_p async_create(int threads)

--- a/tests/test-async.c
+++ b/tests/test-async.c
@@ -73,6 +73,5 @@ int main(void)
     Async.wait(async);
     clock_gettime(CLOCK_REALTIME, &now);
     fprintf(stderr, "# elapsed time: (%lf) ms\n", time_diff(start, now));
-    free(async);
     return 0;
 }


### PR DESCRIPTION
i'm sorry for my mistake that added `free(async)` under test-async.c, the memory leak will also happen.
